### PR TITLE
Sanitize generated LinkML and Mermaid identifiers

### DIFF
--- a/src/dump_yaml.py
+++ b/src/dump_yaml.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import os.path
-import re
 from collections import defaultdict
 from functools import lru_cache
 from itertools import chain
@@ -26,6 +25,7 @@ from common_functions import (
 )
 from external_ontologies import external_ontologies_dict, load_external_ontologies
 from formatter_url_parsing import get_formatter_urls
+from identifier_utils import sanitize_identifier
 from linkml_structures import linkml_schema
 from predicate_mappings import (
     CLASS_TYPES,
@@ -46,19 +46,11 @@ from registry_processing import read_from_registry, schema_from_existing
 # --- Global State ---
 formatter_urls = None
 UNPREFIXED_IRI_WARNING_LIMIT = 1000
-INVALID_LINKML_KEY_CHARACTERS = re.compile(r"[^A-Za-z0-9_]+")
-REPEATED_UNDERSCORES = re.compile(r"_+")
 
 
 def sanitize_linkml_key(value):
     """Create a conservative LinkML element name without changing its RDF IRI."""
-    key = INVALID_LINKML_KEY_CHARACTERS.sub("_", value)
-    key = REPEATED_UNDERSCORES.sub("_", key).strip("_")
-    if not key:
-        key = "iri"
-    if key[0].isdigit():
-        key = f"iri_{key}"
-    return key
+    return sanitize_identifier(value)
 
 
 def get_graph(graph_to_read):
@@ -293,12 +285,11 @@ class GraphCharacterizer:
         output_curie = self.replace_prefixes(uri_str)
         is_unprefixed_iri = isinstance(uri, URIRef) and output_curie == uri_str
 
+        output_key = sanitize_linkml_key(
+            output_curie.replace(":", "_").replace("/", "_")
+        )
         if is_unprefixed_iri:
-            output_key = sanitize_linkml_key(output_curie)
             self.warn_unprefixed_iri(uri_str, output_key)
-        else:
-            # Preserve existing keys for recognized CURIEs and non-IRI values.
-            output_key = output_curie.replace(":", "_").replace("/", "_")
 
         if isinstance(uri, URIRef):
             self.check_linkml_key_collision(uri_str, output_key)

--- a/src/dump_yaml.py
+++ b/src/dump_yaml.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import os.path
+import re
 from collections import defaultdict
 from functools import lru_cache
 from itertools import chain
@@ -44,6 +45,20 @@ from registry_processing import read_from_registry, schema_from_existing
 
 # --- Global State ---
 formatter_urls = None
+UNPREFIXED_IRI_WARNING_LIMIT = 1000
+INVALID_LINKML_KEY_CHARACTERS = re.compile(r"[^A-Za-z0-9_]+")
+REPEATED_UNDERSCORES = re.compile(r"_+")
+
+
+def sanitize_linkml_key(value):
+    """Create a conservative LinkML element name without changing its RDF IRI."""
+    key = INVALID_LINKML_KEY_CHARACTERS.sub("_", value)
+    key = REPEATED_UNDERSCORES.sub("_", key).strip("_")
+    if not key:
+        key = "iri"
+    if key[0].isdigit():
+        key = f"iri_{key}"
+    return key
 
 
 def get_graph(graph_to_read):
@@ -167,6 +182,9 @@ class GraphCharacterizer:
         self.formatter_urls_found = defaultdict(int)
 
         self.parsed_uris = {}
+        self.unprefixed_iris = set()
+        self.unprefixed_iri_warnings_suppressed = False
+        self.linkml_key_iris = {}
 
         # Optimization: Pre-build indexes immediately
         self._build_indexes()
@@ -238,6 +256,33 @@ class GraphCharacterizer:
             self.schema["prefixes"][replacement] = str(prefix)
         return node
 
+    def warn_unprefixed_iri(self, iri, output_key):
+        if iri in self.unprefixed_iris:
+            return
+
+        if len(self.unprefixed_iris) < UNPREFIXED_IRI_WARNING_LIMIT:
+            self.unprefixed_iris.add(iri)
+            logging.warning(
+                "IRI could not be converted to a CURIE; using LinkML key %s: %s",
+                output_key,
+                iri,
+            )
+        elif not self.unprefixed_iri_warnings_suppressed:
+            logging.warning(
+                "Suppressing warnings for additional IRIs that could not be converted "
+                "to CURIEs after %d unique IRIs",
+                UNPREFIXED_IRI_WARNING_LIMIT,
+            )
+            self.unprefixed_iri_warnings_suppressed = True
+
+    def check_linkml_key_collision(self, iri, output_key):
+        previous_iri = self.linkml_key_iris.setdefault(output_key, iri)
+        if previous_iri != iri:
+            raise ValueError(
+                f"IRIs {previous_iri!r} and {iri!r} produce the same LinkML key "
+                f"{output_key!r}"
+            )
+
     @lru_cache(maxsize=100000)
     def produce_curie_key(self, uri):
         """
@@ -246,7 +291,18 @@ class GraphCharacterizer:
         """
         uri_str = str(uri)
         output_curie = self.replace_prefixes(uri_str)
-        output_key = output_curie.replace(":", "_").replace("/", "_")
+        is_unprefixed_iri = isinstance(uri, URIRef) and output_curie == uri_str
+
+        if is_unprefixed_iri:
+            output_key = sanitize_linkml_key(output_curie)
+            self.warn_unprefixed_iri(uri_str, output_key)
+        else:
+            # Preserve existing keys for recognized CURIEs and non-IRI values.
+            output_key = output_curie.replace(":", "_").replace("/", "_")
+
+        if isinstance(uri, URIRef):
+            self.check_linkml_key_collision(uri_str, output_key)
+
         return output_curie, output_key
 
     def process_restrictions(self):

--- a/src/erdiagramgen_okn.py
+++ b/src/erdiagramgen_okn.py
@@ -12,6 +12,8 @@ from linkml_runtime.utils.schemaview import SchemaView
 from linkml._version import __version__
 from linkml.utils.generator import Generator, shared_arguments
 
+from identifier_utils import sanitize_identifier
+
 MERMAID_SERIALIZATION = str
 
 
@@ -223,7 +225,7 @@ class ERDiagramGenerator(Generator):
     def add_upstream_class(self, class_name: ClassDefinitionName, targets: Set[str], diagram: ERDiagram) -> None:
         sv = self.schemaview
         cls = sv.get_class(class_name)
-        entity = Entity(name=camelcase(cls.name))
+        entity = Entity(name=sanitize_identifier(camelcase(cls.name)))
         diagram.entities.append(entity)
         for slot in sv.class_induced_slots(class_name):
             if slot.range in targets:
@@ -241,7 +243,7 @@ class ERDiagramGenerator(Generator):
             return
         sv = self.schemaview
         cls = sv.get_class(class_name)
-        entity = Entity(name=camelcase(cls.name))
+        entity = Entity(name=sanitize_identifier(camelcase(cls.name)))
         diagram.entities.append(entity)
         for slot in sv.class_induced_slots(class_name):
             # TODO: schemaview should infer this
@@ -274,18 +276,25 @@ class ERDiagramGenerator(Generator):
                     rel = Relationship(
                         first_entity=entity.name,
                         relationship_type=rel_type,
-                        second_entity=camelcase(sv.get_class(any_of_type.range).name),
+                        second_entity=sanitize_identifier(
+                            camelcase(sv.get_class(any_of_type.range).name)
+                        ),
                         relationship_label=slot.name,
                     )
                     diagram.relationships.append(rel)
                 except AttributeError:
-                    attr = Attribute(name=underscore(slot.name), datatype=any_of_type.range)
+                    attr = Attribute(
+                        name=sanitize_identifier(underscore(slot.name)),
+                        datatype=sanitize_identifier(any_of_type.range),
+                    )
                     entity.attributes.append(attr)
         else:
             rel = Relationship(
                 first_entity=entity.name,
                 relationship_type=rel_type,
-                second_entity=camelcase(sv.get_class(slot.range).name),
+                second_entity=sanitize_identifier(
+                    camelcase(sv.get_class(slot.range).name)
+                ),
                 relationship_label=slot.name,
             )
             diagram.relationships.append(rel)
@@ -304,7 +313,10 @@ class ERDiagramGenerator(Generator):
         if slot.multivalued:
             # NOTE: mermaid does not support []s or *s in attribute types
             dt = f"{dt}List"
-        attr = Attribute(name=underscore(slot.name), datatype=dt)
+        attr = Attribute(
+            name=sanitize_identifier(underscore(slot.name)),
+            datatype=sanitize_identifier(dt),
+        )
         entity.attributes.append(attr)
 
 

--- a/src/identifier_utils.py
+++ b/src/identifier_utils.py
@@ -1,0 +1,16 @@
+import re
+
+
+INVALID_IDENTIFIER_CHARACTERS = re.compile(r"[^A-Za-z0-9_-]+")
+REPEATED_UNDERSCORES = re.compile(r"_+")
+
+
+def sanitize_identifier(value):
+    """Create an identifier safe for LinkML keys and Mermaid ER diagrams."""
+    identifier = INVALID_IDENTIFIER_CHARACTERS.sub("_", value)
+    identifier = REPEATED_UNDERSCORES.sub("_", identifier).strip("_")
+    if not identifier:
+        identifier = "iri"
+    if not (identifier[0].isalpha() or identifier[0] == "_"):
+        identifier = f"iri_{identifier}"
+    return identifier

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_dump_yaml.py
+++ b/tests/test_dump_yaml.py
@@ -1,0 +1,118 @@
+import logging
+
+import pytest
+from linkml_runtime.utils.formatutils import camelcase
+from rdflib import URIRef
+
+from dump_yaml import (
+    UNPREFIXED_IRI_WARNING_LIMIT,
+    GraphCharacterizer,
+    sanitize_linkml_key,
+)
+
+
+def make_characterizer():
+    characterizer = object.__new__(GraphCharacterizer)
+    characterizer.schema = {"prefixes": {}}
+    characterizer.unprefixed_iris = set()
+    characterizer.unprefixed_iri_warnings_suppressed = False
+    characterizer.linkml_key_iris = {}
+    return characterizer
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("frbr:Endeavour", "frbr_Endeavour"),
+        ("http://example.test/Foo.Bar#Baz", "http_example_test_Foo_Bar_Baz"),
+        ("https://example.test/a-b?x=1", "https_example_test_a_b_x_1"),
+        ("123", "iri_123"),
+        ("///", "iri"),
+    ],
+)
+def test_sanitize_linkml_key(value, expected):
+    assert sanitize_linkml_key(value) == expected
+
+
+def test_produce_curie_key_preserves_unprefixed_iri(caplog):
+    characterizer = make_characterizer()
+    iri = URIRef("https://unregistered.example.test/Foo.Bar#Baz")
+
+    with caplog.at_level(logging.WARNING):
+        output_curie, output_key = characterizer.produce_curie_key(iri)
+
+    assert output_curie == str(iri)
+    assert output_key == "https_unregistered_example_test_Foo_Bar_Baz"
+    assert "IRI could not be converted to a CURIE" in caplog.text
+
+
+def test_frbr_regression_produces_safe_mermaid_entity_name():
+    characterizer = make_characterizer()
+    iri = URIRef("http://purl.org/vocab/frbr/core/Endeavour")
+
+    output_curie, output_key = characterizer.produce_curie_key(iri)
+
+    assert output_curie == str(iri)
+    assert output_key == "http_purl_org_vocab_frbr_core_Endeavour"
+    assert camelcase(output_key) == "HttpPurlOrgVocabFrbrCoreEndeavour"
+
+
+def test_produce_curie_key_preserves_existing_curie_key_format(caplog):
+    characterizer = make_characterizer()
+    iri = URIRef("http://gnis-ld.org/lod/gnis/ontology/County")
+
+    with caplog.at_level(logging.WARNING):
+        output_curie, output_key = characterizer.produce_curie_key(iri)
+
+    assert output_curie == "gnis-ld-gnis:County"
+    assert output_key == "gnis-ld-gnis_County"
+    assert "IRI could not be converted to a CURIE" not in caplog.text
+
+
+def test_produce_curie_key_deduplicates_unprefixed_iri_warning(caplog):
+    characterizer = make_characterizer()
+    iri = URIRef("https://unregistered.example.test/Foo")
+
+    with caplog.at_level(logging.WARNING):
+        characterizer.produce_curie_key(iri)
+        characterizer.produce_curie_key.cache_clear()
+        characterizer.produce_curie_key(iri)
+
+    messages = [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("IRI could not be converted to a CURIE")
+    ]
+    assert len(messages) == 1
+
+
+def test_unprefixed_iri_warnings_are_capped(caplog):
+    characterizer = make_characterizer()
+
+    with caplog.at_level(logging.WARNING):
+        for index in range(UNPREFIXED_IRI_WARNING_LIMIT + 2):
+            characterizer.produce_curie_key(
+                URIRef(f"https://unregistered.example.test/term/{index}")
+            )
+
+    iri_warnings = [
+        record
+        for record in caplog.records
+        if record.message.startswith("IRI could not be converted to a CURIE")
+    ]
+    suppression_warnings = [
+        record
+        for record in caplog.records
+        if record.message.startswith("Suppressing warnings for additional IRIs")
+    ]
+    assert len(iri_warnings) == UNPREFIXED_IRI_WARNING_LIMIT
+    assert len(suppression_warnings) == 1
+    assert len(characterizer.unprefixed_iris) == UNPREFIXED_IRI_WARNING_LIMIT
+
+
+def test_linkml_key_collision_fails_fast():
+    characterizer = make_characterizer()
+    characterizer.produce_curie_key(URIRef("https://unregistered.example.test/a-b"))
+
+    with pytest.raises(ValueError, match="produce the same LinkML key"):
+        characterizer.produce_curie_key(URIRef("https://unregistered.example.test/a_b"))

--- a/tests/test_dump_yaml.py
+++ b/tests/test_dump_yaml.py
@@ -25,8 +25,9 @@ def make_characterizer():
     [
         ("frbr:Endeavour", "frbr_Endeavour"),
         ("http://example.test/Foo.Bar#Baz", "http_example_test_Foo_Bar_Baz"),
-        ("https://example.test/a-b?x=1", "https_example_test_a_b_x_1"),
+        ("https://example.test/a-b?x=1", "https_example_test_a-b_x_1"),
         ("123", "iri_123"),
+        ("3DModel", "iri_3DModel"),
         ("///", "iri"),
     ],
 )
@@ -67,6 +68,35 @@ def test_produce_curie_key_preserves_existing_curie_key_format(caplog):
     assert output_curie == "gnis-ld-gnis:County"
     assert output_key == "gnis-ld-gnis_County"
     assert "IRI could not be converted to a CURIE" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("iri", "expected_curie", "expected_key"),
+    [
+        (
+            "http://w3id.org/fio/v1/epa-frs#Agency.Agriculture",
+            "fio-epa-frs:Agency.Agriculture",
+            "fio-epa-frs_Agency_Agriculture",
+        ),
+        (
+            "http://sail.ua.edu/ruralkg/justice/DataElement14-TypePropertyLoss_Etc.",
+            "rural:justice/DataElement14-TypePropertyLoss_Etc.",
+            "rural_justice_DataElement14-TypePropertyLoss_Etc",
+        ),
+        (
+            "https://stko-kwg.geog.ucsb.edu/lod/ontology#S2Cell",
+            "kwgos:#S2Cell",
+            "kwgos_S2Cell",
+        ),
+    ],
+)
+def test_produce_curie_key_sanitizes_prefixed_iris(iri, expected_curie, expected_key):
+    characterizer = make_characterizer()
+
+    output_curie, output_key = characterizer.produce_curie_key(URIRef(iri))
+
+    assert output_curie == expected_curie
+    assert output_key == expected_key
 
 
 def test_produce_curie_key_deduplicates_unprefixed_iri_warning(caplog):
@@ -112,7 +142,7 @@ def test_unprefixed_iri_warnings_are_capped(caplog):
 
 def test_linkml_key_collision_fails_fast():
     characterizer = make_characterizer()
-    characterizer.produce_curie_key(URIRef("https://unregistered.example.test/a-b"))
+    characterizer.produce_curie_key(URIRef("https://unregistered.example.test/a.b"))
 
     with pytest.raises(ValueError, match="produce the same LinkML key"):
         characterizer.produce_curie_key(URIRef("https://unregistered.example.test/a_b"))

--- a/tests/test_erdiagramgen_okn.py
+++ b/tests/test_erdiagramgen_okn.py
@@ -1,0 +1,37 @@
+from linkml_runtime.linkml_model.meta import (
+    ClassDefinition,
+    SchemaDefinition,
+    SlotDefinition,
+)
+
+from erdiagramgen_okn import ERDiagramGenerator
+
+
+def test_mermaid_identifiers_are_sanitized():
+    schema = SchemaDefinition(
+        id="https://example.test/schema",
+        name="test",
+        classes={
+            "3DModel": ClassDefinition(
+                name="3DModel",
+                slots=["property.with#punctuation"],
+            ),
+            "fio-epa-frs_Agency.Agriculture": ClassDefinition(
+                name="fio-epa-frs_Agency.Agriculture"
+            ),
+            "kwgos_#S2Cell": ClassDefinition(name="kwgos_#S2Cell"),
+        },
+        slots={
+            "property.with#punctuation": SlotDefinition(
+                name="property.with#punctuation",
+                range="type.with#punctuation",
+            )
+        },
+    )
+
+    diagram = ERDiagramGenerator(schema, format="mermaid").serialize()
+
+    assert "iri_3DModel {" in diagram
+    assert "Fio-epa-frsAgency_Agriculture {" in diagram
+    assert "Kwgos_S2Cell {" in diagram
+    assert "type_with_punctuation property_with_punctuation" in diagram


### PR DESCRIPTION
## Summary
- Sanitize every generated LinkML key after CURIE conversion while preserving complete RDF IRIs in `class_uri` and `slot_uri`.
- Replace Mermaid-invalid punctuation and guard identifiers that begin with digits.
- Sanitize Mermaid entity, attribute, and datatype identifiers defensively for legacy or imported schemas.
- Warn for the first 1,000 unique IRIs that cannot be converted to CURIEs, then emit one suppression warning.
- Fail fast when distinct IRIs sanitize to the same generated key.

Related: frink-okn/Proto-OKN-User-Group-Feedback#6

## Testing
- `pytest`: 16 passed.
- Ruff checks passed.
- Mermaid 10.4.0 accepted diagrams regenerated from all 25 locally regenerable graph-description schemas.
- A focused DREAM, FIO, Rural, and UFOKN fixture passed Mermaid 10.4.0. DREAM’s full checked-in schema could not be regenerated because its referenced local import files are absent.